### PR TITLE
Added alias for the garp.php file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,8 @@ RUN \
 
 	npm i -g gulp && \
 	npm i -g bower && \
-	npm i -g jshint
+	npm i -g jshint \
+	alias g='/vendor/grrr-amsterdam/garp3/scripts/garp.php'
 
 EXPOSE 80
 


### PR DESCRIPTION
This should shorten running commands in the docker a little. This should only put the alias in the container so you can keep your local alias independent from docker.

Could be combined with a local alias like:
`alias dex="docker exec -i -t"`

for an end result of:
`dex g spawn`
